### PR TITLE
Fix comtradetools quirks, add docs and offline test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md
+
+## Project overview
+
+Python/Jupyter data-analysis project for **UN Comtrade** trade statistics, focused on trade
+between **China and the Portuguese-speaking countries (PLPs)** and Macau's role as a platform.
+Author: Joaquim Carvalho, Universidade Politécnica de Macau.
+
+The deliverables are **notebooks** and their generated outputs (Excel tables + PNG charts in
+`reports/`). There is no test suite and no package build.
+
+## Layout
+
+- `comtradetools.py` — single core module (~1,930 lines). All API access, caching, reference
+  data, and Excel helpers live here. Notebooks import it; keep logic here rather than in notebooks.
+- `*.ipynb` — 10 analysis notebooks (China/HK/Macau/Taiwan ↔ PLP flows, commodities, country profiles).
+- `*_README.md` — per-notebook documentation, mostly in **Portuguese** (project's working
+  language; an `_EN` variant exists for some). Match the existing language when editing docs.
+- `support/` — reference data: codebook, HS codes, M49 country codes, partner/reporter CSVs.
+- `cache/` — pickled API responses (~2,476 files). Gitignored. Do not delete casually.
+- `reports/` — generated outputs (`.xlsx`, `.png`). Filenames follow
+  `<Country|China>_<section>_<description>_<years>.<ext>` — keep this convention.
+- `docs/` — `comtradetools.md` (**full module manual — read it before non-trivial changes
+  to `comtradetools.py`**), `BULK_DATA_IMPLEMENTATION_PLAN.md` (planned bulk-download support).
+- `config.ini` — API key, **gitignored, never commit or print it**. `config.ini.sample` is the template.
+
+## Environment & setup
+
+- Python **3.10** (`.python-version`), dependencies in `requirements.txt`; virtualenv in `venv/`
+  (`source venv/bin/activate`).
+- A UN Comtrade API key goes in `config.ini` (`[comtrade] key = ...`). Without it the public
+  preview endpoint caps results at **500 rows**, which can silently produce **wrong aggregates**.
+- First-time setup is done via notebook `0-comtrade-setup-first.ipynb`.
+
+## How the code works (important for edits)
+
+Full function-by-function reference: **`docs/comtradetools.md`**. Essentials:
+
+### Architecture
+
+```
+notebooks ──► get_trade_flows() ─┐
+                                 ├─► getFinalData() ──► comtradeapicall_getFinalData() ──► UN Comtrade API
+notebooks ──► getFinalData() ────┘        (cache + period split)      (rate limit 1/20 s)
+```
+
+- **Module-level global state.** `init()` populates globals (`APIKEY`, `COUNTRY_CODES`,
+  `HS_CODES`, …) from `support/` reference files (downloading them if missing) and then
+  calls `clean_cache()`. Notebooks call `setup()` → `get_api_key()` → `init(APIKEY)` once
+  per session; `INIT_DONE` guards re-init unless `force_init=True`.
+- **`getFinalData()` is the single API entry point.** It forces `partner2Code=0`
+  (prevents double counting — manual §5.1), splits `period` into ≤12-period chunks
+  (`split_period()`; one **cache pickle per chunk**), retries failures (`MAX_RETRIES=5`,
+  linear backoff, then `IOError`), and caches each chunk for `CACHE_VALID_DAYS = 90`.
+  When testing API-facing changes, expect cached results — pass `cache=False` or clear
+  the specific pickle to force a live call. Returns an **empty DataFrame**, not `None`,
+  when there is no data.
+- **Wrapper-only kwargs** consumed by `getFinalData` (not forwarded to the API):
+  `cache`, `retry_if_empty`, `remove_world`, `period_size`, `use_alternative`.
+- **Rate limit is frozen at import time** by the `@limits(calls=1, period=20)` decorator.
+  Reassigning `PERIOD_SECONDS`/`CALLS_PER_PERIOD` after import (some notebooks and the
+  `__main__` block do this) has **no effect** — edit the constants in the file instead.
+- **Mirror (symmetric) data**: `get_trade_flows()` reports flows `X`, `M` plus `X<M`
+  (exports inferred from partners' imports) and `M<X` (imports inferred from partners'
+  exports). Values legitimately differ (CIF/FOB, reporting gaps) — surface both.
+- Countries are **UN M49 numeric codes**. Use the module constants (`m49_china`,
+  `m49_plp_list`, …), never hardcoded numbers (China is `156`).
+- Excel output styling goes through `excel_col_autowidth()`, `excel_format_currency()`,
+  `excel_format_percent()`. Reuse them for new reports.
+- Trade values are in **current US dollars**; percentage columns use the module's
+  `PERC_CMD_IN_PARTNER` / `PERC_PARTNER_IN_CMD` labels.
+
+### Deprecated code — do not extend
+
+| Function | Use instead |
+|---|---|
+| `get_trade_flows_old()` | `get_trade_flows()` |
+| `top_commodities()`, `top_partners()` | `getFinalData()` + pandas ranking (see `cn_plp_commodities.ipynb`, `country_trade_profile.ipynb`) |
+| `get_data()` | `getFinalData()` |
+
+### Common pitfalls (details in manual §5)
+
+- `partnerCode=None` returns a World row (`partnerCode=0`) alongside partners —
+  use `remove_world=True` before aggregating.
+- Mixing HS levels or `motCode`/`customsCode` aggregates with details double-counts;
+  `checkAggregateValues()` flags HS parent codes (see `isaggregate_bug.ipynb`).
+- Any parameter change (even `includeDesc`) creates a new cache entry; `clean_cache()`
+  runs on every `init()` and deletes entries older than 90 days.
+- `encode_country`/`decode_country` pass unknown inputs through unchanged instead of
+  failing — check outputs.
+
+## Conventions
+
+- Code, identifiers, and comments in English; user-facing docs/reports largely in Portuguese.
+- Style: PEP 8, `max-line-length = 100` (`.flake8`), though `comtradetools.py` disables E501.
+  Docstrings use Google style (`Args:` / `Returns:`).
+- The module relies on module-level globals for config (`APIKEY`, reference DataFrames);
+  preserve this pattern rather than refactoring to classes — notebooks depend on it.
+- Notebooks are executed interactively; outputs are committed. Keep notebooks runnable
+  top-to-bottom (`jupyter nbconvert --execute` should succeed).
+
+## Gotchas
+
+- `support/` CSVs with spaces in names (`REF  MOS.csv` — note the double space) are referenced
+  by exact filename; don't rename. Gitignored `REF *.csv` files regenerate from
+  `support/codebook.xlsx` worksheets on `init()` (see manual §4.1).
+- `docs/BULK_DATA_IMPLEMENTATION_PLAN.md` describes planned bulk-download support — check it
+  before adding new data-access paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ between **China and the Portuguese-speaking countries (PLPs)** and Macau's role 
 Author: Joaquim Carvalho, Universidade Politécnica de Macau.
 
 The deliverables are **notebooks** and their generated outputs (Excel tables + PNG charts in
-`reports/`). There is no test suite and no package build.
+`reports/`). Tests live in `tests/` (pytest, no network — the API layer is mocked); there is
+no package build.
 
 ## Layout
 
@@ -28,6 +29,8 @@ The deliverables are **notebooks** and their generated outputs (Excel tables + P
 
 - Python **3.10** (`.python-version`), dependencies in `requirements.txt`; virtualenv in `venv/`
   (`source venv/bin/activate`).
+- Run tests with `venv/bin/python -m pytest tests/ -q` (31 tests, all offline; `conftest.py`
+  at repo root puts the repo on `sys.path` and provides the hermetic `ctt` init fixture).
 - A UN Comtrade API key goes in `config.ini` (`[comtrade] key = ...`). Without it the public
   preview endpoint caps results at **500 rows**, which can silently produce **wrong aggregates**.
 - First-time setup is done via notebook `0-comtrade-setup-first.ipynb`.

--- a/PROJECT_ANALYSIS.md
+++ b/PROJECT_ANALYSIS.md
@@ -122,6 +122,8 @@ cipf-comtrade/
 ├── *.ipynb                   # Analysis notebooks (10)
 ├── *_README.md/pdf           # Notebook documentation
 ├── support/                  # Reference data & codebooks
+├── tests/                    # pytest suite for comtradetools.py (offline, mocked API)
+├── conftest.py               # pytest bootstrap: sys.path + hermetic init fixture
 ├── cache/                    # Cached API responses (gitignored, ~2,476 pickles)
 ├── reports/                  # Generated reports (~470 files)
 ├── downloads/                # Downloaded files

--- a/PROJECT_ANALYSIS.md
+++ b/PROJECT_ANALYSIS.md
@@ -2,32 +2,37 @@
 
 ## Overview
 
-This is a **Python data analysis project** for accessing and analyzing **UN Comtrade** (United Nations international trade statistics database) data, specifically focused on **trade relations between China and Portuguese-speaking countries (PLPs)** and the role of Macau as a trade platform.
+This is a **Python data analysis project** for accessing and analyzing **UN Comtrade**
+(United Nations international trade statistics database) data, specifically focused on
+**trade relations between China and Portuguese-speaking countries (PLPs)** and the role
+of Macau as a trade platform.
 
 ## Project Structure
 
 | Component | Description |
 |-----------|-------------|
-| **Main Module** | `comtradetools.py` (~1,900 lines) - Core utilities for UN Comtrade API access |
-| **Notebooks** | 8+ Jupyter notebooks for various trade analyses |
+| **Main Module** | `comtradetools.py` (~1,930 lines) — core utilities for UN Comtrade API access |
+| **Notebooks** | 10 Jupyter notebooks for setup and trade analyses |
 | **Support** | Reference data, codebooks, HS codes, country codes |
-| **Cache** | 372 cached API responses (pickle files) |
-| **Reports** | 302 generated reports |
+| **Cache** | ~2,476 cached API responses (pickle files, gitignored) |
+| **Reports** | ~470 generated reports (375 Excel, 92 PNG) |
+| **Docs** | `docs/comtradetools.md` (module manual), `docs/BULK_DATA_IMPLEMENTATION_PLAN.md` |
 
 ## Key Features
 
 ### 1. API Integration
-- Wraps the `comtradeapicall` official package
-- Rate limiting (1 call/20 seconds)
-- Automatic caching (60-day validity)
-- Handles API pagination (max 12 periods per request)
+- Wraps the `comtradeapicall` official package via a single entry point, `getFinalData()`
+- Rate limiting (1 call / 20 seconds, bound at import time)
+- Automatic pickle caching (90-day validity, `CACHE_VALID_DAYS = 90`)
+- Handles API pagination (max 12 periods per request, transparent splitting)
+- Forces `partner2Code=0` by default to avoid double counting (see manual §5.1)
 
 ### 2. Analysis Capabilities
-- Import/export totals between countries
-- Top commodities analysis (HS nomenclature)
+- Import/export totals between countries, with mirror (partner-reported) values
+- Top commodities analysis (HS nomenclature, up to 6-digit)
 - Top trading partners ranking
-- Trade balance calculations
-- Symmetric value reporting (reporter vs. partner perspectives)
+- Trade balance and trade volume calculations
+- Product/partner dependency analysis (`total_rank_perc`)
 
 ### 3. Portuguese-Speaking Countries Focus
 - Angola, Brazil, Cabo Verde, Guinea-Bissau, Equatorial Guinea
@@ -38,43 +43,43 @@ This is a **Python data analysis project** for accessing and analyzing **UN Comt
 
 | Notebook | Purpose |
 |----------|---------|
-| `cn_plp_import_export.ipynb` | China ↔ PLPs trade flows |
+| `0-comtrade-setup-first.ipynb` | First-time setup: API key configuration |
+| `cn_plp_import_export.ipynb` | China ↔ PLPs trade flows (+ Forum Macau–comparable Excel tables) |
 | `hk_plp_import_export.ipynb` | Hong Kong ↔ PLPs trade |
 | `mo_plp_import_export.ipynb` | Macau ↔ PLPs trade |
 | `tw_plp_import_export.ipynb` | Taiwan ↔ PLPs trade |
 | `cn_plp_commodities.ipynb` | Top commodities analysis |
-| `country_trade_profile.ipynb` | Country trade profiles |
-| `comtrade-api.ipynb` | API exploration |
+| `cn_plp_partner2.ipynb` | Partner2 (second partner) analysis — standalone, does not use comtradetools |
+| `country_trade_profile.ipynb` | Country trade profiles (products, partners, dependency) |
+| `comtrade-api.ipynb` | API exploration sandbox |
+| `isaggregate_bug.ipynb` | Reproduction of the HS aggregate double-counting issue |
+
+Most notebooks have companion `*_README.md`/`.pdf` documentation (Portuguese; some English).
 
 ## Tech Stack
 
-- **Python 3** (version in `.python-version`)
-- **pandas** - Data manipulation
-- **matplotlib** - Visualization
-- **openpyxl/xlsxwriter** - Excel export
-- **comtradeapicall** - Official UN Comtrade API client
-- **ratelimit** - API rate limiting
-- **Jupyter** - Interactive analysis
+- **Python 3.10** (`.python-version`: 3.10.9; virtualenv in `venv/`)
+- **pandas** — data manipulation
+- **matplotlib** — visualization
+- **openpyxl/xlsxwriter** — Excel export
+- **comtradeapicall** — official UN Comtrade API client
+- **ratelimit** — API rate limiting
+- **Jupyter + ipywidgets + itables** — interactive analysis
 
 ## Dependencies
 
+See `requirements.txt`:
+
 ```
-pandas
-matplotlib
-requests
-openpyxl
-xlsxwriter
-tabulate
-ipywidgets
-jinja2
-ratelimit
-comtradeapicall
-itables
+pandas, matplotlib, requests, openpyxl, xlsxwriter, tabulate,
+ipywidgets, jinja2, ratelimit, comtradeapicall, itables
 ```
 
 ## Configuration
 
-Requires a **UN Comtrade API key** (stored in `config.ini`). Without it, results are limited to 500 rows per request.
+Requires a **UN Comtrade API key** (stored in `config.ini`, gitignored; template in
+`config.ini.sample`). Without it the preview endpoint limits results to 500 rows per
+request, which can silently produce wrong aggregates.
 
 ### Getting an API Key
 
@@ -83,35 +88,45 @@ Requires a **UN Comtrade API key** (stored in `config.ini`). Without it, results
 3. Select "Premium Individual APIs"
 4. Subscribe to "comtrade - v1"
 5. Wait for email with API key
-6. Add key to `config.ini`
+6. Run notebook `0-comtrade-setup-first.ipynb` and add the key to `config.ini`
 
 ## Main Functions in comtradetools.py
 
-| Function | Description |
-|----------|-------------|
-| `init()` | Initialize module, load codebooks |
-| `getFinalData()` | Main API wrapper with caching and rate limiting |
-| `get_trade_flows()` | Get import/export totals for a country |
-| `top_commodities()` | Get top traded commodities |
-| `top_partners()` | Get top trading partners |
-| `year_range()` | Generate year range strings |
-| `excel_col_autowidth()` | Excel formatting utilities |
+Full reference: **[docs/comtradetools.md](docs/comtradetools.md)**.
+
+| Function | Status | Description |
+|----------|--------|-------------|
+| `setup()` / `init()` / `get_api_key()` | current | Configure module, load reference codebooks |
+| `getFinalData()` | current | Main API wrapper: caching, rate limiting, period splitting |
+| `get_trade_flows()` | current | Import/export totals with mirror values |
+| `total_rank_perc()`, `subtotal()`, `rank()` | current | DataFrame subtotal/rank/percentage helpers |
+| `make_format()` | current | pandas number-format dict builder |
+| `excel_col_autowidth()`, `excel_format_currency()`, `excel_format_percent()` | current | Excel formatting |
+| `checkAggregateValues()` | current | Flag HS parent (aggregate) codes |
+| `encode_country()` / `decode_country()` | current | M49 code ↔ name mapping |
+| `year_range()`, `split_period()`, `get_year_intervals()` | current | Period string helpers |
+| `get_trade_flows_old()` | DEPRECATED | superseded by `get_trade_flows()` |
+| `top_commodities()`, `top_partners()` | DEPRECATED | use `getFinalData()` + pandas ranking |
+| `get_data()` | DEPRECATED | raw REST caller predating `comtradeapicall` |
 
 ## Directory Structure
 
 ```
 cipf-comtrade/
-├── comtradetools.py          # Main module
-├── config.ini                # API configuration
+├── comtradetools.py          # Main module (manual: docs/comtradetools.md)
+├── config.ini                # API configuration (gitignored)
+├── config.ini.sample         # Template for config.ini
 ├── requirements.txt          # Dependencies
-├── README.md                 # Documentation
-├── *.ipynb                   # Analysis notebooks
+├── README.md                 # Documentation (Portuguese)
+├── AGENTS.md                 # Agent-oriented project guide
+├── *.ipynb                   # Analysis notebooks (10)
 ├── *_README.md/pdf           # Notebook documentation
 ├── support/                  # Reference data & codebooks
-├── cache/                    # Cached API responses
-├── reports/                  # Generated reports
+├── cache/                    # Cached API responses (gitignored, ~2,476 pickles)
+├── reports/                  # Generated reports (~470 files)
 ├── downloads/                # Downloaded files
-└── web/                      # Web assets
+├── docs/                     # Module manual & design notes
+└── web/                      # Web assets (cn_plp_import_export)
 ```
 
 ## Author

--- a/comtradetools.py
+++ b/comtradetools.py
@@ -1237,7 +1237,8 @@ def get_trade_flows(
                 ]
             )
 
-    global_trade = pd.concat([global_trade, exports_from_imports, imports_from_exports])
+    if symmetric_values:
+        global_trade = pd.concat([global_trade, exports_from_imports, imports_from_exports])
 
     trade_balance = pd.pivot_table(
         global_trade, index=["period"], columns="flowCode", values="primaryValue"

--- a/comtradetools.py
+++ b/comtradetools.py
@@ -627,9 +627,9 @@ def getFinalData(*p, **kwp):
                     logging.debug("Call returned None")
                 else:
                     logging.debug("Number of record in temp: %s", temp.size)
-            except Exception as e:
-                logging.error(
-                    "Error in getFinalData, retrying in %s seconds: %s", MAX_SLEEP, e
+            except Exception:
+                logging.exception(
+                    "Error in getFinalData, retrying in %s seconds", MAX_SLEEP
                 )
                 time.sleep(MAX_SLEEP)
                 RETRY += 1

--- a/comtradetools.py
+++ b/comtradetools.py
@@ -149,8 +149,6 @@ PERC_CMD_IN_PARTNER = "perc_cmd_for_partner"
 # label for the percentage of a country in the total trade of a commodity
 PERC_PARTNER_IN_CMD = "perc_partner_for_cmd"
 
-INIT_DONE = False
-
 INIT_DONE = False  # flag to avoid multiple initialization
 
 
@@ -212,7 +210,7 @@ def init(
     """Set the API Key and codebooks for the module
 
     Args:
-        apy_key (Union[str,None], optional): API Key. Defaults to None.
+        api_key (Union[str,None], optional): API Key. Defaults to None.
         code_book_url (Union[None,str], optional): URL to download codebook. Defaults to None.
         force_init (bool, optional): Force initialization. Defaults to False.
     """
@@ -383,28 +381,30 @@ def init(
     # INIT_DONE = True
 
 
-def encode_country(country: str) -> str:
+def encode_country(country: str) -> Union[str, int]:
     """Encode country name to country code
 
     Args:
         country (str): Country name
 
     Returns:
-        str: Country code
+        Union[str, int]: M49 country code (int), or the input
+            unchanged if the name is unknown
     """
     global COUNTRY_CODES_REVERSE
 
     return COUNTRY_CODES_REVERSE.get(country, country)
 
 
-def decode_country(country_code: str) -> str:
+def decode_country(country_code: Union[str, int]) -> Union[str, int]:
     """Decode country code to country name
 
     Args:
-        country_code (str): Country code
+        country_code (Union[str, int]): M49 country code (codes are ints)
 
     Returns:
-        str: Country name
+        Union[str, int]: Country name, or the input unchanged
+            if the code is unknown
     """
     global COUNTRY_CODES
     return COUNTRY_CODES.get(country_code, country_code)
@@ -628,9 +628,8 @@ def getFinalData(*p, **kwp):
                 else:
                     logging.debug("Number of record in temp: %s", temp.size)
             except Exception as e:
-                sleep = MAX_SLEEP * (RETRY + 1)
                 logging.error(
-                    f"Error in getFinalData, retrying in {MAX_SLEEP} seconds", e
+                    "Error in getFinalData, retrying in %s seconds: %s", MAX_SLEEP, e
                 )
                 time.sleep(MAX_SLEEP)
                 RETRY += 1
@@ -789,7 +788,7 @@ def top_commodities(
 
     DEPRECATED
     Args:
-        reporterCode (str): reporter country code, e.g. 49 for China
+        reporterCode (str): reporter country code, e.g. 156 for China
         partnerCode (str): partner country code, 0 for the world, None for all, code or CSV
         partner2Code (str): partner2 country code, 0 for world,
                             -1 all but World, None for all, default 0
@@ -902,7 +901,7 @@ def get_trade_flows_old(
     Get the Import/Export totals for a given country and year range
 
     Args:
-        country_of_interest (str): country of interest, e.g. 49 for China
+        country_of_interest (str): country of interest, e.g. 156 for China
         years (str): year range, e.g. 2010,2011,2012
         symmetric_values: if True report also exports from partner imports
                           and imports from partners exports; default True
@@ -1074,7 +1073,7 @@ def get_trade_flows(
     Get the Import/Export totals for a given country and year range
 
     Args:
-        country_of_interest (str): country of interest, e.g. 49 for China
+        country_of_interest (str): country of interest, e.g. 156 for China
         years (str): year range, e.g. 2010,2011,2012
         period_size(int): number of periods to request in each call; defaults to 1
         retry_if_empty (bool): retry if the cached result is empty; defaults to True
@@ -1284,7 +1283,7 @@ def top_partners(
 
         DEPRECATED
     Args:
-        reporterCode (str): reporter country code, e.g. 49 for China, or a CSV list
+        reporterCode (str): reporter country code, e.g. 156 for China, or a CSV list
         years (str): year range, e.g. 2010,2011,2012
         cmdCode (str): HS code, e.g. TOTAL for all commodities, or AG2,
                         AG4 or specific code or list of
@@ -1610,39 +1609,12 @@ def checkAggregateValues(
     return df
 
 
-# create main function
-if __name__ == "__main__":
-    print("contrade.py initializing...")
-    Path("support").mkdir(parents=True, exist_ok=True)
-    Path("reports").mkdir(parents=True, exist_ok=True)
-    fname = "config.ini"
-    content = """
-    # Config file
-    [comtrade]
-    # Add API Key. DO NOT SHARE
-    key =
-    """
-    if not os.path.isfile(fname):
-        print("Creating file config.ini")
-        with open(fname, "w", encoding="utf-8") as f:
-            f.write(content)
-        print("Add API Key. Get one at https://comtradedeveloper.un.org/ ")
-    if os.path.isfile(fname):
-        config = configparser.ConfigParser()
-        config.read("config.ini")
-        # get API Key or set to None
-        APIKEY = config["comtrade"].get("key", None)
-    init(APIKEY, force_init=True)
-    PERIOD_SECONDS = 7
-    print("contrade.py initialized")
-
-
 @sleep_and_retry
 @limits(calls=CALLS_PER_PERIOD, period=PERIOD_SECONDS)
 def get_data(
     typeCode: str,
     freqCode: str,
-    reporterCode: str = "49",
+    reporterCode: str = "156",
     partnerCode: str = "024,076,132,226,624,508,620,678,626",
     partner2Code: str = 0,
     period: str = None,
@@ -1668,7 +1640,7 @@ def get_data(
     Args:
         typeCode (str): Type of data to retrieve, C for commodities, S for Services
         freqCode (str): Frequency of data, A for annual, M for monthly
-        reporterCode (str, optional): Reporter country code. Defaults to '49'.
+        reporterCode (str, optional): Reporter country code. Defaults to '156' (China).
         partnerCode (str, optional): Partner country code. Defaults to
                                         '024,076,132,226,624,508,620,678,626'.
         partner2Code (str, optional): Partner2 country code. Defaults to 0 (world).
@@ -1905,7 +1877,7 @@ def get_data(
 
 # create main function
 if __name__ == "__main__":
-    print("contrade.py initializing...")
+    print("comtrade.py initializing...")
     Path("support").mkdir(parents=True, exist_ok=True)
     Path("reports").mkdir(parents=True, exist_ok=True)
     fname = "config.ini"
@@ -1926,5 +1898,4 @@ if __name__ == "__main__":
         # get API Key or set to None
         APIKEY = config["comtrade"].get("key", None)
     init(APIKEY, force_init=True)
-    PERIOD_SECONDS = 7
-    print("contrade.py initialized")
+    print("comtrade.py initialized")

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,52 @@
+"""Pytest bootstrap: make the repo root importable and provide shared fixtures."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Support files init() needs locally (anything missing would trigger a download)
+REQUIRED_SUPPORT_FILES = [
+    "codebook.xlsx",
+    "dataitem.csv",
+    "partner.csv",
+    "reporter.csv",
+    "harmonized-system.csv",
+    "Dim_Countries_Hierarchy_UnctadStat_All_Flat.csv",
+    "COMTRADE+ COMPLETE.csv",
+    "REF COUNTRIES.csv",
+    "REF  MOS.csv",
+    "REF CUSTOMS.csv",
+    "REF FLOWS.csv",
+    "REF MOT.csv",
+    "REF QTY.csv",
+]
+
+
+@pytest.fixture(scope="session")
+def ctt(tmp_path_factory):
+    """Import and initialize comtradetools the way the notebooks do, but hermetically.
+
+    Uses a throwaway config.ini (dummy key) and a throwaway cache dir so tests
+    never touch the real config or the real cache. Skips if the local support
+    files are absent, because init() would then need network access.
+    """
+    support = Path("support")
+    missing = [f for f in REQUIRED_SUPPORT_FILES if not (support / f).is_file()]
+    if missing:
+        pytest.skip(f"support files missing, init() would need network: {missing}")
+
+    import comtradetools
+
+    tmp = tmp_path_factory.mktemp("ctt")
+    config = tmp / "config.ini"
+    config.write_text("[comtrade]\nkey = TESTKEY\n")
+    cache = tmp / "cache"
+
+    comtradetools.setup(
+        support_dir="support", cache_dir=str(cache), config_file=str(config)
+    )
+    comtradetools.init("TESTKEY")
+    return comtradetools

--- a/conftest.py
+++ b/conftest.py
@@ -7,22 +7,23 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-# Support files init() needs locally (anything missing would trigger a download)
+# Support files init() needs but that are NOT committed in git:
+# - "REF *.csv" and "COMTRADE+ COMPLETE.csv" are regenerated locally by init()
+#   from the committed codebook.xlsx worksheets, so they need no check.
+# - "Dim_Countries_Hierarchy_UnctadStat_All_Flat.csv" would be downloaded from
+#   UNCTAD, but comtradetools never reads it (init() only downloads it), so a
+#   placeholder keeps the suite fully offline (created below if missing).
+# Only the committed files are hard requirements; without them init() would
+# hit the network (comtradeapicall.getReference / HS code download).
 REQUIRED_SUPPORT_FILES = [
     "codebook.xlsx",
     "dataitem.csv",
     "partner.csv",
     "reporter.csv",
     "harmonized-system.csv",
-    "Dim_Countries_Hierarchy_UnctadStat_All_Flat.csv",
-    "COMTRADE+ COMPLETE.csv",
-    "REF COUNTRIES.csv",
-    "REF  MOS.csv",
-    "REF CUSTOMS.csv",
-    "REF FLOWS.csv",
-    "REF MOT.csv",
-    "REF QTY.csv",
 ]
+
+COUNTRY_GROUPS_FILE = Path("support/Dim_Countries_Hierarchy_UnctadStat_All_Flat.csv")
 
 
 @pytest.fixture(scope="session")
@@ -30,13 +31,13 @@ def ctt(tmp_path_factory):
     """Import and initialize comtradetools the way the notebooks do, but hermetically.
 
     Uses a throwaway config.ini (dummy key) and a throwaway cache dir so tests
-    never touch the real config or the real cache. Skips if the local support
-    files are absent, because init() would then need network access.
+    never touch the real config or the real cache. Skips only if a committed
+    support file is absent, because init() would then need network access.
     """
     support = Path("support")
     missing = [f for f in REQUIRED_SUPPORT_FILES if not (support / f).is_file()]
     if missing:
-        pytest.skip(f"support files missing, init() would need network: {missing}")
+        pytest.skip(f"committed support files missing, init() needs network: {missing}")
 
     import comtradetools
 
@@ -48,5 +49,16 @@ def ctt(tmp_path_factory):
     comtradetools.setup(
         support_dir="support", cache_dir=str(cache), config_file=str(config)
     )
+
+    # Placeholder so init() skips the UNCTAD download; the file is never read.
+    created_placeholder = False
+    if not COUNTRY_GROUPS_FILE.is_file():
+        COUNTRY_GROUPS_FILE.write_text("")
+        created_placeholder = True
+
     comtradetools.init("TESTKEY")
-    return comtradetools
+
+    yield comtradetools
+
+    if created_placeholder:
+        COUNTRY_GROUPS_FILE.unlink()

--- a/docs/comtradetools.md
+++ b/docs/comtradetools.md
@@ -1,0 +1,418 @@
+# comtradetools.py — Source Documentation & Manual
+
+Complete reference for the `comtradetools` module (~1,930 lines), the core utility layer
+of this project. All notebooks import it; all UN Comtrade API access flows through it.
+
+For orientation and project-wide conventions see `AGENTS.md`; for a project inventory see
+`PROJECT_ANALYSIS.md`.
+
+---
+
+## 1. Architecture
+
+```
+notebooks
+   │
+   ├─ setup() / init()                one-time configuration & reference-data loading
+   │
+   ├─ get_trade_flows()               high-level analysis (import/export totals + mirror data)
+   │
+   └─ getFinalData()                  general-purpose API wrapper
+          │  • splits periods into chunks (≤12 per API call)
+          │  • per-chunk pickle cache in cache/ (md5 of parameters)
+          │  • forces partner2Code=0 to avoid double counting
+          │  • retries on failure / empty results
+          ▼
+     comtradeapicall_getFinalData()   rate-limited inner wrapper (1 call / 20 s)
+          ▼
+     comtradeapicall.getFinalData()   official UN Comtrade package
+          ▼
+     https://comtradeapi.un.org/data/v1/get/   (or /public/v1/preview/ without a key)
+```
+
+Design traits to be aware of before editing:
+
+- **Module-level global state.** Configuration (`APIKEY`) and every reference table
+  (`COUNTRY_CODES`, `HS_CODES`, …) are module globals populated by `init()`. Notebooks
+  depend on this pattern — do not refactor into classes.
+- **Two API layers coexist.** The modern path wraps the official `comtradeapicall` package
+  (`getFinalData`). The older path (`get_data`) builds raw REST URLs by hand and is
+  deprecated, as are `top_commodities`, `top_partners`, `get_trade_flows_old`.
+- **Caching is transparent and aggressive.** Identical calls are served from `cache/`
+  for 90 days without touching the network. Keep this in mind when testing.
+
+---
+
+## 2. Quick start
+
+Minimal notebook preamble (pattern used across all notebooks):
+
+```python
+import comtradetools
+
+comtradetools.setup()                 # create support/, cache/, config.ini if missing
+APIKEY = comtradetools.get_api_key()  # read key from config.ini
+comtradetools.init(APIKEY)            # load reference tables into module globals
+
+# general query — China's imports (M) from all PLPs, 2020–2022, HS 2-digit
+df = comtradetools.getFinalData(
+    typeCode="C", freqCode="A", clCode="HS",
+    reporterCode=comtradetools.m49_china,          # 156
+    partnerCode=comtradetools.m49_plp_list,        # "24,76,132,624,226,508,620,678,626"
+    period=comtradetools.year_range(2020, 2022),   # "2020,2021,2022"
+    flowCode="M", cmdCode="AG2",
+    motCode=0, customsCode="C00",
+)
+
+# high-level: import/export totals with mirror (partner-reported) values
+tb = comtradetools.get_trade_flows(
+    countryOfInterest=comtradetools.m49_china,
+    period=comtradetools.year_range(2014, 2023),
+    partners=comtradetools.m49_plp_list,
+)
+```
+
+Running `python comtradetools.py` directly executes the `__main__` block: it creates
+`support/`, `reports/`, a stub `config.ini`, then runs `init(APIKEY, force_init=True)`,
+which downloads/refreshes all reference tables.
+
+---
+
+## 3. Configuration
+
+### `config.ini`
+
+```ini
+[comtrade]
+key = YOUR_UN_COMTRADE_API_KEY
+```
+
+- Gitignored — never commit. Template: `config.ini.sample`.
+- Without a key the module falls back to the public **preview endpoint**, capped at
+  **500 rows per request** — this can silently produce wrong aggregates. The literal
+  placeholder value `APIKEYHERE` is treated the same as "no key" (`get_url()`).
+
+### Module constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `BASE_URL_PREVIEW` | `https://comtradeapi.un.org/public/v1/preview/` | unauthenticated endpoint |
+| `BASE_URL_API` | `https://comtradeapi.un.org/data/v1/get/` | authenticated endpoint |
+| `CALLS_PER_PERIOD` | `1` | rate-limit: calls allowed per period |
+| `PERIOD_SECONDS` | `20` | rate-limit: period length (seconds) |
+| `MAX_RETRIES` | `5` | retries for failed/empty API calls |
+| `MAX_SLEEP` | `6` | base backoff between retries (s); actual sleep = `MAX_SLEEP * (RETRY+1)` |
+| `CACHE_VALID_DAYS` | `90` | max age of cache entries |
+| `SUPPORT_DIR` / `CACHE_DIR` | `support` / `cache` | reference data / pickle cache dirs |
+| `CONFIG_FILE` | `config.ini` | config file path |
+| `PERC_CMD_IN_PARTNER` | `"perc_cmd_for_partner"` | column label: share of a commodity in a partner's trade |
+| `PERC_PARTNER_IN_CMD` | `"perc_partner_for_cmd"` | column label: share of a partner in a commodity's trade |
+
+### PLP country codes (UN M49)
+
+`m49_angola=24`, `m49_brazil=76`, `m49_cabo_verde=132`, `m49_guine_bissau=624`,
+`m49_guine_equatorial=226`, `m49_mozambique=508`, `m49_portugal=620`,
+`m49_stome_principe=678`, `m49_timor=626`; plus `m49_china=156`, `m49_hong_kong=344`,
+`m49_macau=446`.
+
+Aggregates: `m49_plp` (list of ints), `m49_plp_list` (comma-joined string, ready for API
+parameters), and after `init()`: `PLP_CODES`, `PLP_CODES_REVERSE`, `PLP_TUPLES`,
+`PLP_TUPLES_REVERSE`.
+
+### Reference-data globals (populated by `init()`)
+
+| Global | Source | Content |
+|---|---|---|
+| `COUNTRY_CODES` | `support/partner.csv` + `reporter.csv` | M49 code → country name (all partners & reporters) |
+| `COUNTRY_CODES_REVERSE` | derived | name → M49 code |
+| `HS_CODES` | `support/harmonized-system.csv` | HS code → description (all levels) |
+| `HS_CODES_L2` | derived | HS 2-digit codes → description |
+| `FLOWS_CODES` / `FLOWS_CODES_CAT` | `support/REF FLOWS.csv` | flow code → description / category (M, X variants) |
+| `CUSTOMS_CODE` | `support/REF CUSTOMS.csv` | customs procedure code → description |
+| `MOS_CODES` | `support/REF  MOS.csv` | mode-of-supply code → description (note: **two spaces** in filename) |
+| `MOT_CODES` | `support/REF MOT.csv` | mode-of-transport code → description |
+| `QTY_CODES` / `QTY_CODES_DESC` | `support/REF QTY.csv` | quantity unit → abbreviation / full description |
+| `COLS_DESC` | `support/COMTRADE+ COMPLETE.csv` | API column → description |
+| `DATA_ITEM_DF` | `support/dataitem.csv` | `comtradeapicall.getReference("dataitem")` |
+| `APIKEY` | `init()` arg | module-wide API key |
+| `INIT_DONE` | — | guard against repeated `init()` (use `force_init=True` to override) |
+
+---
+
+## 4. Function reference
+
+### 4.1 Setup & initialization
+
+#### `setup(support_dir="support", cache_dir="cache", config_file="config.ini")`
+Creates the support and cache directories and a stub config file if missing (logs a
+warning to add the API key). Updates the `SUPPORT_DIR` / `CACHE_DIR` / `CONFIG_FILE`
+globals. Call first in every notebook.
+
+#### `get_api_key() -> str`
+Reads `key` from `[comtrade]` in `CONFIG_FILE`. Raises if the file/section is missing.
+
+#### `init(api_key=None, code_book_url=None, force_init=False)`
+One-time initialization; a no-op if `INIT_DONE` unless `force_init=True`.
+
+Steps: downloads the codebook (`support/codebook.xlsx`) if missing and exports each
+worksheet to `support/<sheet>.csv`; downloads the UNCTAD country-groups CSV; loads every
+reference table listed in §3 into globals (fetching `partner`, `reporter`, `dataitem`
+references via `comtradeapicall.getReference` when the CSV is absent); loads HS codes;
+builds the PLP dicts; **calls `clean_cache()`**, deleting cache entries older than 90 days.
+
+Note on fresh clones: the gitignored `support/REF *.csv` and `COMTRADE+ COMPLETE.csv`
+files are **regenerated locally** from worksheets of the committed `support/codebook.xlsx`
+— the sheet names match the filenames exactly, including the double-space `REF  MOS`.
+Only `Dim_Countries_Hierarchy_UnctadStat_All_Flat.csv` (UNCTAD download) requires network
+on first `init()`; `partner.csv`, `reporter.csv`, `dataitem.csv` are committed and only
+re-fetched via `comtradeapicall.getReference` if deleted.
+
+#### `clean_cache()`
+Deletes every file in `CACHE_DIR` older than `CACHE_VALID_DAYS` (90 days), by file mtime.
+Called automatically by `init()`. There is no per-key invalidation — to force a fresh
+API response, either delete the specific pickle, pass `cache=False` to `getFinalData`,
+or wait out the 90 days.
+
+#### `get_url(api_key=None)`
+Returns the authenticated base URL when a real key is given, the preview URL when the
+key is `None` or the literal `"APIKEYHERE"`. Used by the deprecated `get_data` only.
+
+### 4.2 Code & period helpers
+
+#### `encode_country(country) `
+Country name → M49 code via `COUNTRY_CODES_REVERSE`. Returns the input unchanged if the
+name is unknown (a silent pass-through — check outputs rather than assuming failure).
+
+#### `decode_country(country_code)`
+M49 code → country name via `COUNTRY_CODES`. Same pass-through behavior. The dict is
+keyed by **integer** codes — the signature accepts `Union[str, int]`, but pass ints.
+
+#### `year_range(year_start=1984, year_end=2030) -> str`
+Returns `"1984,1985,…,2030"` — the comma-separated period format the API expects.
+
+#### `split_period(period, max_periods=12) -> list[str]`
+Splits a comma-separated period string into chunks of at most `max_periods`. Used by
+`getFinalData` to respect the API's 12-periods-per-call limit.
+
+#### `get_year_intervals(years) -> list[str]`
+Collapses a sorted list of years into interval strings:
+`[2018,2019,2021] → ["2018-2019", "2021-2021"]`. Used for report titles/labels, not API
+calls.
+
+### 4.3 Core data access: `getFinalData`
+
+#### `getFinalData(*p, **kwp) -> pd.DataFrame`
+
+The single entry point for all modern API queries. Signature is intentionally generic:
+one optional positional argument (the API key — defaults to `get_api_key()` from
+`config.ini` when omitted; **not** the `APIKEY` global) plus keyword arguments forwarded
+to `comtradeapicall.getFinalData` (`typeCode`, `freqCode`, `clCode`, `reporterCode`,
+`partnerCode`, `partner2Code`, `period`, `cmdCode`, `flowCode`, `motCode`,
+`customsCode`, `includeDesc`, … — see the
+[comtradeapicall docs](https://github.com/uncomtrade/comtradeapicall)).
+
+Wrapper-specific keyword arguments (consumed by the wrapper, not forwarded):
+
+| Arg | Default | Effect |
+|---|---|---|
+| `cache` | `True` | cache each period-chunk result as a pickle in `cache/` |
+| `retry_if_empty` | `True` | discard cached empty results and re-fetch |
+| `remove_world` | `False` | drop `partnerCode == 0` rows from the final result (relevant when `partnerCode=None`) |
+| `period_size` | `12` | chunk size for period splitting |
+| `use_alternative` | `False` | use `comtradeapicall._getFinalData` (private, "optimized" variant — untested) |
+
+Behavior, in order:
+
+1. Defaults `partner2Code` to `0` if not given — **this is load-bearing**, see §5.1.
+2. Requires `period`; raises `ValueError` otherwise.
+3. Splits `period` via `split_period(period, period_size)` and processes each chunk:
+   - Computes an `md5` of the parameter dict (+ `use_alternative`) → `cache/<hash>.pickle`.
+   - Fresh-enough cache hit (≤ 90 days) → load; empty cached frame → re-fetch unless
+     `retry_if_empty=False`; stale → delete and re-fetch.
+   - Miss → call the rate-limited inner wrapper. On exception: one immediate retry.
+     On `None` result: up to `MAX_RETRIES` (5) attempts with linear backoff
+     (`MAX_SLEEP * (RETRY+1)` seconds), then raises `IOError`.
+   - Successful non-empty chunks are written to cache; all-NA frames are dropped with a warning.
+4. Concatenates chunks; applies `remove_world` if requested.
+
+Returns an **empty DataFrame** (not `None`) when every chunk came back empty.
+Cached results are returned instantly — the rate limiter only guards live calls.
+
+#### `comtradeapicall_getFinalData(*p, **kwp)`
+Thin inner wrapper decorated with `@sleep_and_retry` + `@limits(calls=1, period=20)`.
+Not meant to be called directly. Note: the decorator arguments are evaluated **at import
+time** — assigning to `comtradetools.PERIOD_SECONDS` or `CALLS_PER_PERIOD` afterwards
+(as some notebooks and the `__main__` block do) has **no effect** on the actual rate limit.
+
+### 4.4 High-level analysis
+
+#### `get_trade_flows(countryOfInterest=None, period=None, typeCode="C", freqCode="A", partners=0, period_size=1, retry_if_empty=True, symmetric_values=True)`
+
+Import/export totals for one country against the world or a set of partners — the current,
+supported version (supersedes `get_trade_flows_old`).
+
+Makes up to four `getFinalData` calls, all with `cmdCode="TOTAL"`, `motCode=0`,
+`customsCode="C00"`, `partner2Code=0`, `includeDesc=True`:
+
+| Result | reporterCode | partnerCode | flowCode |
+|---|---|---|---|
+| reported imports | country of interest | partners | M |
+| reported exports | country of interest | partners | X |
+| mirror exports `X<M` | partners (None if world) | country of interest | M |
+| mirror imports `M<X` | partners (None if world) | country of interest | X |
+
+The mirror calls (`symmetric_values=True`, the default) recover the country's exports as
+**reported by its partners' imports** (`X<M`) and vice versa (`M<X`) — essential when the
+country of interest reports poorly (e.g. some PLPs in some years).
+
+Returns a pivot DataFrame indexed by `period` with one column per flow present plus
+derived columns (each added only when its inputs exist):
+
+- `trade_balance (X-M)`, `trade_balance (X<M-M)`, `trade_balance (X<M-M<X)`
+- `trade_volume (X+M)`, `trade_volume (X<M+M)`, `trade_volume (X<M+M<X)`
+
+Mirror values normally differ from directly reported ones (CIF vs FOB valuation, partner
+attribution, reporting gaps) — surface both, never "reconcile" them.
+
+### 4.5 Deprecated functions (kept for backward compatibility)
+
+| Function | Status | Replacement |
+|---|---|---|
+| `get_trade_flows_old(...)` | DEPRECATED | `get_trade_flows()` (adds `period_size`, `retry_if_empty`, more balance columns) |
+| `top_commodities(reporterCode, partnerCode=0, years=None, flowCode="M,X", partner2Code=0, cmdCode="AG2", motCode=None, rank_filter=5, return_data=False, timeout=120, echo_url=False)` | DEPRECATED | `getFinalData` + pandas ranking (see `cn_plp_commodities.ipynb`) |
+| `top_partners(reporterCode=0, years=None, cmdCode="TOTAL", flowCode="M,X", partnerCode=None, partner2Code=0, motCode=0, customsCode="C00", rank_*_filter=None, return_data=False, ...)` | DEPRECATED | `getFinalData` + pandas ranking (see `country_trade_profile.ipynb`) |
+| `get_data(typeCode, freqCode, reporterCode="156", partnerCode=<PLPs>, partner2Code=0, period=None, clCode="HS", cmdCode="TOTAL", flowCode="M,X", customsCode="C00", more_pars=None, qtyUnitCodeFilter=None, motCode=None, apiKey=None, cache=True, timeout=10, echo_url=False)` | DEPRECATED | `getFinalData()` — `get_data` hand-builds REST URLs and predates the official package |
+
+The deprecated `top_*` functions still work and document the project's standard
+enrichment columns (`sum_*`, `perc_*`, `rank_*`, `perc_cmd_for_partner`,
+`perc_partner_for_cmd`) — useful reading even if you don't call them.
+
+### 4.6 DataFrame utilities
+
+#### `subtotal(df, groupby, col)`
+`df.groupby(groupby)[col].transform("sum")` — per-group sum aligned to the original rows.
+
+#### `rank(df, rankby, col)`
+Dense descending rank of `col` within each `rankby` group, as `int`.
+
+#### `total_rank_perc(df, groupby, col, prefix, rankby=None, percby=None, drop_duplicates=True)`
+Adds five columns summarizing `col` over `groupby`:
+
+- `{prefix}_sum` — subtotal per full group
+- `{prefix}_rank` — rank of the group subtotal within `rankby` (default `groupby[:-1]`)
+- `{prefix}_perc` — row value as share of the parent-group subtotal
+- `{prefix}_upper_sum` — parent-group subtotal (`groupby[:-1]`)
+- `{prefix}_upper_perc` — group subtotal as share of the parent subtotal
+
+Then drops duplicate rows on `groupby` (disable with `drop_duplicates=False`).
+**Mutates the input frame** while computing. Used heavily by `country_trade_profile.ipynb`
+(e.g. rank products within year × flow, with the share of each product in the year total).
+
+#### `make_format(cols) -> dict`
+Builds a pandas format dict: `{0:.3%}` for columns ending in `perc`, `${0:,.0f}` for
+columns ending in `sum` and for `primaryValue`. For `DataFrame.style.format(...)` or
+`to_excel` post-processing.
+
+### 4.7 Excel export (xlsxwriter via `pd.ExcelWriter`)
+
+Pattern used in notebooks:
+
+```python
+with pd.ExcelWriter("reports/out.xlsx", engine="xlsxwriter") as writer:
+    df.to_excel(writer, sheet_name="data")
+    comtradetools.excel_col_autowidth(df, writer, sheet="data")
+    comtradetools.excel_format_currency(df, writer, sheet="data", columns=["primaryValue"])
+    comtradetools.excel_format_percent(df, writer, sheet="data", columns=["perc_x"])
+```
+
+- `excel_col_autowidth(data_frame, excel_file, sheet=None, consider_headers=True)` —
+  sets each column's width to the longest content (headers included, capped at 100);
+  handles multi-level indices. Column offset accounting depends on the number of index
+  levels — call it on the same frame you wrote.
+- `excel_format_currency(..., columns=None, format_currency="$#,##0", width=None)` —
+  defaults to all numeric columns.
+- `excel_format_percent(..., columns=None, format_perc="0.00%", width=None)` —
+  same defaults.
+
+### 4.8 Validation
+
+#### `checkAggregateValues(df, hcode_column, aggregate_column="isCmdAggregate")`
+Flags rows whose hierarchical code is a **parent** of the next row's code (e.g. `"01"`
+followed by `"0101"` → `"01"` is an aggregate). Requires the frame to be **sorted
+ascending by `hcode_column`** (a TODO in the source notes the function could sort itself).
+Warns on duplicated codes. Used to avoid double counting when mixing HS levels —
+see `isaggregate_bug.ipynb` for the motivating bug.
+
+---
+
+## 5. Data semantics & pitfalls
+
+### 5.1 The `partner2Code` double-counting trap
+
+When an API call omits `partner2Code`, UN Comtrade may return, for the same
+reporter/partner/year, one row per second partner **plus** an extra row with
+`partner2Code = 0` containing their aggregate — i.e. the total appears twice if you sum
+naively. `getFinalData` therefore **forces `partner2Code=0`** unless you explicitly pass
+another value. Pass `partner2Code=None` only if you genuinely want the breakdown (and
+then deduplicate yourself). The docstring of `getFinalData` carries a worked example
+(China → Equatorial Guinea, 2015).
+
+### 5.2 `partnerCode=None` includes the World row
+
+With `partnerCode=None` the API returns both the world (`partnerCode=0`) and every
+individual partner. Use `remove_world=True` (or filter `df.partnerCode != 0`) before
+aggregating, or totals double.
+
+### 5.3 Aggregate rows and mixed granularity
+
+Queries spanning several HS levels (e.g. `AG2` + specific codes) can return both parents
+and children. Watch the `isAggregate` column and use `checkAggregateValues` when in doubt.
+The same class of problem exists for `motCode` (0 = all modes) and `customsCode`
+(C00 = all procedures): the deprecated `get_data` warns when a result mixes aggregates
+with details; `getFinalData` does not — pass explicit `motCode=0, customsCode="C00"`
+as the notebooks do.
+
+### 5.4 Empty results
+
+No data for a (country, year, flow) combination is a normal occurrence, not an error:
+empty chunks are skipped and the wrapper returns an empty DataFrame. A `None` return from
+the underlying package is retried and ultimately raises `IOError` — treat persistent
+`IOError` as "API unreachable or query rejected", not "no data".
+
+### 5.5 Cache key sensitivity
+
+The cache hash covers the full forwarded parameter dict (after wrapper-only args are
+stripped) **plus the sub-period string**. Consequences:
+
+- One pickle per period chunk — a 30-year query = 3 cache files at `period_size=12`,
+  30 files at `period_size=1`. The same logical query with different `period_size`
+  populates different cache entries.
+- Any parameter change (including cosmetic ones like `includeDesc`) yields a new entry.
+- Cached frames are returned as pickled — column sets reflect the call that created them.
+
+### 5.6 Rate limiting is import-time bound
+
+`@limits(calls=CALLS_PER_PERIOD, period=PERIOD_SECONDS)` freezes `1 / 20 s` at import.
+Reassigning the constants later changes nothing (some notebooks do this — it is a no-op).
+To actually change the limit, edit the constants at the top of the file before import.
+Note also that premium Comtrade keys allow higher rates — the 20 s default is
+conservative; `comtradeapicall`'s own limiter may also apply.
+
+### 5.7 Misc quirks
+
+- `encode_country` / `decode_country` never fail loudly: unknown inputs pass through
+  unchanged — check outputs rather than assuming failure.
+
+---
+
+## 6. Where things are used
+
+| Consumer | comtradetools API used |
+|---|---|
+| `0-comtrade-setup-first.ipynb` | `setup`, `get_api_key`, `init` |
+| `cn_plp_import_export.ipynb`, `hk_/mo_/tw_plp_import_export.ipynb` | `getFinalData`, `year_range`, `split_period` |
+| `cn_plp_commodities.ipynb` | `getFinalData`, `year_range`, `encode_country`, `excel_col_autowidth`, `excel_format_currency`, M49 constants |
+| `country_trade_profile.ipynb` | `get_trade_flows`, `getFinalData`, `total_rank_perc`, `make_format`, `year_range`, `HS_CODES`, `encode_country` |
+| `comtrade-api.ipynb` | `getFinalData`, `year_range`, `decode_country` (API exploration/sandbox) |
+| `isaggregate_bug.ipynb` | `decode_country` (repro for the aggregate-values issue, §4.8) |
+| `cn_plp_partner2.ipynb` | (does not import comtradetools) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ jinja2
 ratelimit
 comtradeapicall
 itables
+pytest
 

--- a/tests/test_comtradetools.py
+++ b/tests/test_comtradetools.py
@@ -1,0 +1,426 @@
+"""Tests for comtradetools.py, mirroring the calls made in the notebooks.
+
+Notebook patterns covered:
+- 0-comtrade-setup-first.ipynb: setup / get_api_key / init
+- cn|hk|mo|tw_plp_import_export.ipynb: getFinalData with notebook kwargs,
+  year_range, split_period
+- country_trade_profile.ipynb: get_trade_flows, total_rank_perc, make_format
+- cn_plp_commodities.ipynb: excel_col_autowidth / excel_format_currency /
+  excel_format_percent, encode_country
+- comtrade-api.ipynb, isaggregate_bug.ipynb: decode_country, checkAggregateValues
+
+No test performs network access: the API layer is replaced by fakes via
+monkeypatch, and caching is redirected to pytest tmp dirs.
+"""
+
+import pandas as pd
+import pytest
+
+import comtradetools
+
+
+def make_api_df(periods=("2020",), reporter=156, partners=(24, 76), flow="M", value=100.0):
+    """Small DataFrame mimicking a comtradeapicall.getFinalData result."""
+    rows = [
+        {
+            "period": per,
+            "refYear": int(per),
+            "reporterCode": reporter,
+            "partnerCode": p,
+            "partner2Code": 0,
+            "cmdCode": "TOTAL",
+            "flowCode": flow,
+            "primaryValue": value,
+        }
+        for per in periods
+        for p in partners
+    ]
+    return pd.DataFrame(rows)
+
+
+class FakeAPI:
+    """Records calls and returns a preset DataFrame (None simulates a failed call)."""
+
+    def __init__(self):
+        self.calls = []
+        self.next_result = None
+
+    def __call__(self, *p, **kwp):
+        self.calls.append(kwp.copy())
+        if self.next_result is None:
+            return None
+        return self.next_result.copy()
+
+
+@pytest.fixture
+def fake_api(monkeypatch, tmp_path):
+    """Replace the rate-limited inner wrapper with a recorder, and redirect the cache."""
+    fake = FakeAPI()
+    fake.next_result = make_api_df()
+    monkeypatch.setattr(comtradetools, "comtradeapicall_getFinalData", fake)
+    monkeypatch.setattr(comtradetools, "CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(comtradetools, "MAX_SLEEP", 0)  # keep retry tests fast
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# setup / get_api_key / init — 0-comtrade-setup-first.ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestSetupInit:
+    def test_setup_creates_dirs_and_config(self, tmp_path):
+        comtradetools.setup(
+            support_dir=str(tmp_path / "support"),
+            cache_dir=str(tmp_path / "cache"),
+            config_file=str(tmp_path / "config.ini"),
+        )
+        assert (tmp_path / "support").is_dir()
+        assert (tmp_path / "cache").is_dir()
+        assert (tmp_path / "config.ini").is_file()
+
+    def test_get_api_key_reads_config(self, ctt):
+        assert ctt.get_api_key() == "TESTKEY"
+
+    def test_init_populates_reference_globals(self, ctt):
+        assert ctt.INIT_DONE is True
+        assert ctt.COUNTRY_CODES[156] == "China"
+        assert ctt.COUNTRY_CODES_REVERSE["China"] == 156
+        assert len(ctt.HS_CODES) > 0
+        assert len(ctt.HS_CODES_L2) > 0
+        assert set(ctt.PLP_CODES) == set(ctt.m49_plp)
+        assert "M" in ctt.FLOWS_CODES
+
+    def test_init_is_noop_unless_forced(self, ctt):
+        sentinel = {"sentinel": 1}
+        original = ctt.COUNTRY_CODES
+        ctt.COUNTRY_CODES = sentinel
+        try:
+            ctt.init("TESTKEY")  # must return early, keeping the sentinel
+            assert ctt.COUNTRY_CODES is sentinel
+        finally:
+            ctt.COUNTRY_CODES = original
+
+    def test_get_url_selects_endpoint(self, ctt):
+        assert ctt.get_url("SOMEKEY") == ctt.BASE_URL_API
+        assert ctt.get_url(None) == ctt.BASE_URL_PREVIEW
+        assert ctt.get_url("APIKEYHERE") == ctt.BASE_URL_PREVIEW
+
+
+# ---------------------------------------------------------------------------
+# encode/decode_country — cn_plp_commodities.ipynb, comtrade-api.ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestCountryCodecs:
+    def test_encode_country(self, ctt):
+        assert ctt.encode_country("China") == 156
+        assert ctt.encode_country("Angola") == 24
+
+    def test_decode_country(self, ctt):
+        assert ctt.decode_country(156) == "China"
+        assert ctt.decode_country(ctt.m49_brazil) == "Brazil"
+
+    def test_unknown_passes_through(self, ctt):
+        assert ctt.encode_country("Atlantis") == "Atlantis"
+        assert ctt.decode_country(9999) == 9999
+
+
+# ---------------------------------------------------------------------------
+# period helpers — all import/export notebooks
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodHelpers:
+    def test_year_range(self):
+        assert comtradetools.year_range(2020, 2022) == "2020,2021,2022"
+        assert comtradetools.year_range(2020, 2020) == "2020"
+
+    def test_split_period_chunks_at_12(self):
+        period = comtradetools.year_range(2000, 2012)  # 13 years
+        chunks = comtradetools.split_period(period)
+        assert len(chunks) == 2
+        assert chunks[0] == comtradetools.year_range(2000, 2011)
+        assert chunks[1] == "2012"
+
+    def test_split_period_short(self):
+        assert comtradetools.split_period("2020,2021") == ["2020,2021"]
+
+    def test_get_year_intervals(self):
+        assert comtradetools.get_year_intervals([2018, 2019, 2021]) == [
+            "2018-2019",
+            "2021-2021",
+        ]
+        assert comtradetools.get_year_intervals([2020]) == ["2020-2020"]
+
+
+# ---------------------------------------------------------------------------
+# getFinalData — cn|hk|mo|tw_plp_import_export.ipynb, cn_plp_commodities.ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestGetFinalData:
+    # kwargs as in cn_plp_import_export.ipynb
+    NOTEBOOK_KWARGS = dict(
+        typeCode="C",
+        freqCode="A",
+        clCode="HS",
+        cmdCode="TOTAL",
+        flowCode="M",
+        reporterCode=156,
+        partner2Code=0,
+        customsCode="C00",
+        motCode="0",
+        includeDesc=True,
+    )
+
+    def test_notebook_style_call(self, fake_api):
+        fake_api.next_result = make_api_df(periods=("2020", "2021"))
+        df = comtradetools.getFinalData(
+            "TESTKEY",
+            partnerCode=comtradetools.m49_plp_list,
+            period=comtradetools.year_range(2020, 2021),
+            **self.NOTEBOOK_KWARGS,
+        )
+        assert len(fake_api.calls) == 1
+        assert len(df) == 2 * 2  # 2 periods x 2 partners in the fake
+        assert df["primaryValue"].sum() > 0
+
+    def test_periods_split_into_chunks(self, fake_api):
+        comtradetools.getFinalData(
+            "TESTKEY",
+            partnerCode=76,
+            period=comtradetools.year_range(2000, 2012),  # 13 years > 12 per call
+            **self.NOTEBOOK_KWARGS,
+        )
+        assert len(fake_api.calls) == 2
+        assert fake_api.calls[0]["period"] == comtradetools.year_range(2000, 2011)
+        assert fake_api.calls[1]["period"] == "2012"
+
+    def test_partner2code_defaults_to_zero(self, fake_api):
+        kwargs = dict(self.NOTEBOOK_KWARGS)
+        del kwargs["partner2Code"]
+        comtradetools.getFinalData("TESTKEY", partnerCode=76, period="2020", **kwargs)
+        assert fake_api.calls[0]["partner2Code"] == 0
+
+    def test_period_is_required(self, fake_api):
+        with pytest.raises(ValueError, match="Period is required"):
+            comtradetools.getFinalData("TESTKEY", partnerCode=76, **self.NOTEBOOK_KWARGS)
+
+    def test_second_identical_call_uses_cache(self, fake_api):
+        kwargs = dict(self.NOTEBOOK_KWARGS, partnerCode=76, period="2020")
+        first = comtradetools.getFinalData("TESTKEY", **kwargs)
+        second = comtradetools.getFinalData("TESTKEY", **kwargs)
+        assert len(fake_api.calls) == 1  # second call served from cache
+        pd.testing.assert_frame_equal(first, second)
+
+    def test_cache_false_forces_refetch(self, fake_api):
+        kwargs = dict(self.NOTEBOOK_KWARGS, partnerCode=76, period="2020")
+        comtradetools.getFinalData("TESTKEY", **kwargs)
+        comtradetools.getFinalData("TESTKEY", cache=False, **kwargs)
+        assert len(fake_api.calls) == 2
+
+    def test_remove_world_drops_partnercode_zero(self, fake_api, monkeypatch):
+        fake_api.next_result = make_api_df(partners=(0, 76, 24))
+        df = comtradetools.getFinalData(
+            "TESTKEY",
+            **self.NOTEBOOK_KWARGS,
+            partnerCode=None,
+            period="2020",
+            remove_world=True,
+        )
+        assert set(df["partnerCode"]) == {76, 24}
+
+    def test_empty_result_returns_empty_dataframe(self, fake_api):
+        fake_api.next_result = pd.DataFrame()
+        df = comtradetools.getFinalData(
+            "TESTKEY", **self.NOTEBOOK_KWARGS, partnerCode=76, period="2020"
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_none_result_retries_then_raises(self, fake_api):
+        fake_api.next_result = None
+        with pytest.raises(IOError):
+            comtradetools.getFinalData(
+                "TESTKEY", **self.NOTEBOOK_KWARGS, partnerCode=76, period="2020"
+            )
+        # 1 initial + MAX_RETRIES retries of the "empty result" loop
+        assert len(fake_api.calls) == 1 + comtradetools.MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# get_trade_flows — country_trade_profile.ipynb
+# ---------------------------------------------------------------------------
+
+
+def trade_flows_fake(monkeypatch):
+    """Fake getFinalData dispatching on reporter/partner/flow like the API would."""
+    calls = []
+
+    def fake(*p, **kwp):
+        calls.append(kwp.copy())
+        periods = tuple(kwp["period"].split(","))
+        flow = kwp["flowCode"]
+        if kwp["reporterCode"] == 24:  # country of interest reports
+            value = 100.0 if flow == "M" else 80.0
+            return make_api_df(periods, reporter=24, partners=(76,), flow=flow, value=value)
+        # partners report (mirror calls): partnerCode is the country of interest
+        value = 90.0 if flow == "M" else 70.0
+        return make_api_df(periods, reporter=76, partners=(24,), flow=flow, value=value)
+
+    monkeypatch.setattr(comtradetools, "getFinalData", fake)
+    return calls
+
+
+class TestGetTradeFlows:
+    # call pattern as in country_trade_profile.ipynb
+    def test_symmetric_flows_and_balance(self, monkeypatch):
+        calls = trade_flows_fake(monkeypatch)
+        tb = comtradetools.get_trade_flows(
+            countryOfInterest=24,
+            period="2020,2021",
+            partners="76,132",
+            period_size=1,
+            retry_if_empty=False,
+            symmetric_values=True,
+        )
+        assert len(calls) == 4  # M, X, and the two mirror calls
+        row = tb.loc["2020"]
+        assert row["M"] == 100.0
+        assert row["X"] == 80.0
+        assert row["X<M"] == 90.0
+        assert row["M<X"] == 70.0
+        assert row["trade_balance (X-M)"] == pytest.approx(-20.0)
+        assert row["trade_balance (X<M-M)"] == pytest.approx(-10.0)
+        assert row["trade_volume (X+M)"] == pytest.approx(180.0)
+        assert row["trade_volume (X<M+M<X)"] == pytest.approx(160.0)
+
+    def test_no_symmetric_values(self, monkeypatch):
+        calls = trade_flows_fake(monkeypatch)
+        tb = comtradetools.get_trade_flows(
+            countryOfInterest=24, period="2020", symmetric_values=False
+        )
+        assert len(calls) == 2
+        assert "X" in tb.columns and "M" in tb.columns
+        assert "X<M" not in tb.columns
+
+    def test_missing_exports_skips_derived_columns(self, monkeypatch):
+        calls = trade_flows_fake(monkeypatch)
+
+        original = comtradetools.getFinalData
+
+        def fake_no_exports(*p, **kwp):
+            if kwp["reporterCode"] == 24 and kwp["flowCode"] == "X":
+                return pd.DataFrame()
+            return original(*p, **kwp)
+
+        monkeypatch.setattr(comtradetools, "getFinalData", fake_no_exports)
+        tb = comtradetools.get_trade_flows(
+            countryOfInterest=24, period="2020", symmetric_values=True
+        )
+        assert "X" not in tb.columns
+        assert "trade_balance (X-M)" not in tb.columns  # guarded
+        assert "trade_balance (X<M-M)" in tb.columns
+
+
+# ---------------------------------------------------------------------------
+# DataFrame utilities — country_trade_profile.ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestDataFrameUtils:
+    SAMPLE = pd.DataFrame(
+        {
+            "year": [2020, 2020, 2020, 2021, 2021, 2021],
+            "flow": ["M"] * 6,
+            "partner": ["A", "B", "C", "A", "B", "C"],
+            "primaryValue": [50.0, 30.0, 20.0, 40.0, 40.0, 20.0],
+        }
+    )
+
+    def test_subtotal(self):
+        out = comtradetools.subtotal(self.SAMPLE, ["year"], "primaryValue")
+        assert out.tolist() == [100.0] * 3 + [100.0] * 3
+
+    def test_rank_dense_descending(self):
+        out = comtradetools.rank(self.SAMPLE, ["year"], "primaryValue")
+        assert out.tolist() == [1, 2, 3, 1, 1, 2]
+
+    def test_total_rank_perc(self):
+        out = comtradetools.total_rank_perc(
+            self.SAMPLE.copy(),
+            groupby=["year", "flow", "partner"],
+            col="primaryValue",
+            prefix="partner",
+        )
+        row = out[(out.year == 2020) & (out.partner == "A")].iloc[0]
+        assert row["partner_sum"] == 50.0
+        assert row["partner_rank"] == 1
+        assert row["partner_perc"] == pytest.approx(0.5)
+        assert row["partner_upper_sum"] == 100.0
+        assert row["partner_upper_perc"] == pytest.approx(0.5)
+        # dense rank tie in 2021
+        ranks_2021 = out[out.year == 2021]["partner_rank"].tolist()
+        assert ranks_2021 == [1, 1, 2]
+
+    def test_make_format(self):
+        fmt = comtradetools.make_format(["a_perc", "b_sum", "primaryValue", "other"])
+        assert fmt["a_perc"] == "{0:.3%}"
+        assert fmt["b_sum"] == "${0:,.0f}"
+        assert fmt["primaryValue"] == "${0:,.0f}"
+        assert "other" not in fmt
+
+
+# ---------------------------------------------------------------------------
+# Excel helpers — cn_plp_commodities.ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestExcelHelpers:
+    DF = pd.DataFrame(
+        {
+            "country": ["Angola", "Brazil"],
+            "primaryValue": [1234567.0, 8910111.0],
+            "perc_x": [0.25, 0.75],
+        }
+    )
+
+    def test_excel_roundtrip(self, tmp_path):
+        from openpyxl import load_workbook
+
+        path = tmp_path / "out.xlsx"
+        df = self.DF.set_index("country")
+        with pd.ExcelWriter(path, engine="xlsxwriter") as writer:
+            df.to_excel(writer, sheet_name="data")
+            comtradetools.excel_col_autowidth(df, writer, sheet="data")
+            comtradetools.excel_format_currency(
+                df, writer, sheet="data", columns=["primaryValue"]
+            )
+            comtradetools.excel_format_percent(df, writer, sheet="data", columns=["perc_x"])
+
+        ws = load_workbook(path)["data"]
+        # xlsxwriter stores a slightly adjusted width; assert it matches within tolerance
+        assert ws.column_dimensions["A"].width == pytest.approx(len("country"), abs=1.0)
+        assert "$" in ws["B2"].number_format
+        assert "%" in ws["C2"].number_format
+
+
+# ---------------------------------------------------------------------------
+# checkAggregateValues — isaggregate_bug.ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAggregateValues:
+    def test_flags_parent_codes(self):
+        df = pd.DataFrame({"cmdCode": ["01", "0101", "02"], "v": [10, 10, 5]})
+        out = comtradetools.checkAggregateValues(df.copy(), "cmdCode")
+        flags = out["isCmdAggregate"]
+        assert flags.iloc[0] == True  # "01" is parent of "0101"  # noqa: E712
+        assert flags.iloc[1] == False  # noqa: E712
+        assert pd.isna(flags.iloc[2])  # last row is never assigned (documented behavior)
+
+    def test_duplicate_codes_warn(self):
+        df = pd.DataFrame({"cmdCode": ["0101", "0101"], "v": [1, 1]})
+        with pytest.warns(UserWarning, match="duplicated"):
+            comtradetools.checkAggregateValues(df.copy(), "cmdCode")


### PR DESCRIPTION
## Summary

Project-init follow-up: source documentation for `comtradetools.py`, a batch of small source fixes, and the project's first automated tests.

### Fixes in `comtradetools.py`
- **Real bug:** `get_trade_flows(symmetric_values=False)` crashed with `UnboundLocalError` (unconditional mirror-flow concat). Found by the new tests.
- Remove duplicate `INIT_DONE` assignment; merge the two identical `__main__` blocks (previously `init(force_init=True)` ran twice on script execution); drop dead `PERIOD_SECONDS` assignment.
- Fix `logging.error(f"...", e)` misuse that dropped the exception text.
- Correct stale '49 for China' references to M49 `156`, including the `get_data()` default (deprecated, unused by notebooks).
- Fix `apy_key` typo in `init()` docstring; honest `Union[str, int]` hints on `encode_country`/`decode_country`.

### Docs
- `AGENTS.md` — agent-oriented project guide.
- `docs/comtradetools.md` — full source manual: architecture, function reference, caching/rate-limit semantics, pitfalls (partner2Code double-counting, world-row inclusion, cache-key sensitivity).
- `PROJECT_ANALYSIS.md` — refreshed with verified stats.

### Tests
- 31 pytest tests in `tests/test_comtradetools.py`, mirroring the calls made in the notebooks. Fully offline: API layer mocked, cache/config redirected to tmp dirs. Run with `venv/bin/python -m pytest tests/ -q`.
- `pytest` added to `requirements.txt`.

Note: `country_trade_profile.ipynb` has unrelated local modifications and is intentionally excluded.
